### PR TITLE
Fix minor problems in day 1, slide 1

### DIFF
--- a/course/day1/1.md
+++ b/course/day1/1.md
@@ -63,7 +63,7 @@ Infix (dyadic) functions have a **short** *left* scope and **long** *right* scop
       10×⍳2+5   
 10 20 30 40 50 60 70
 ```
-The expresssion above is "two *times* the indices from 1 to *two plus five*, or in short: "two times iota two plus five". We can make it clearer using (superfluous) **parentheses** `()`.
+The expresssion above is "ten *times* the indices from 1 to *two plus five*, or in short: "ten times iota two plus five". We can make it clearer using (superfluous) **parentheses** `()`.
 ```APL
       10×(⍳(2+5))
 10 20 30 40 50 60 70
@@ -82,7 +82,7 @@ Of course, we can change the order of execution using different parentheses.
 
     2. @@1785 = \sum_{n=1}^{17}n^2@@ (add together the first seventeen squared integers)
 
-    3. @@10100 = \sum_{n=1}^{100}2n@@ (add together the first one hundred even integers)
+    3. @@10100 = \sum_{n=1}^{100}2n@@ (add together the first one hundred positive even integers)
 
     4. @@10000 = \sum_{n=1}^{100}2n-1@@ (add together the first one hundred odd integers)
 
@@ -136,6 +136,6 @@ Of course, we can change the order of execution using different parentheses.
         
         Answer: `256`
 
-    4.  Find the mean average value of `⎕AVU`.
+    4.  Find the mean of `⎕AVU`.
         
         Answer: `2523.875`


### PR DESCRIPTION
 - the English transcription of the APL expression `10×⍳2+5` was wrong;

 - as $0$ is an even number, the sum $2 + 4 + \cdots + 200$ is more well-specified if you say "first one hundred _positive_ even integers";

 - "Find the mean average value of `⎕AVU`" sounds redundant - if not wrong. I suggest going with "Find the mean of `⎕AVU`" or "Find the average value of `⎕AVU`".